### PR TITLE
Terminal API

### DIFF
--- a/public/css/timeclock.css
+++ b/public/css/timeclock.css
@@ -116,3 +116,21 @@ html, body { height:100% }
   .calendar.day { display:none }
   .calendar p { display:inline }
 }
+
+@media (min-width: 1400px) {
+  .container {
+    max-width: 1300px !important;
+  }
+}
+
+@media (min-width: 1600px) {
+  .container {
+    max-width: 1400px !important;
+  }
+}
+
+@media (min-width: 1700px) {
+  .container {
+    max-width: 1600px !important;
+  }
+}

--- a/src/api/TerminalAuthentication.php
+++ b/src/api/TerminalAuthentication.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\api;
+
+use app\models\Terminal;
+use yii\filters\auth\HttpBearerAuth;
+
+class TerminalAuthentication extends HttpBearerAuth
+{
+    public function authenticate($user, $request, $response)
+    {
+        $authHeader = $request->getHeaders()->get($this->header);
+
+        if ($authHeader !== null) {
+            if ($this->pattern !== null) {
+                if (preg_match($this->pattern, $authHeader, $matches)) {
+                    $authHeader = $matches[1];
+                } else {
+                    return null;
+                }
+            }
+
+            $identity = Terminal::findIdentityByAccessToken($authHeader);
+            if ($identity === null) {
+                $this->challenge($response);
+                $this->handleFailure($response);
+            }
+
+            return $identity;
+        }
+
+        return null;
+    }
+}

--- a/src/api/controllers/TerminalController.php
+++ b/src/api/controllers/TerminalController.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\api\controllers;
+
+use app\api\TerminalAuthentication;
+use app\models\Clock;
+use app\models\Off;
+use app\models\Terminal;
+use app\models\User;
+use DateTime;
+use Yii;
+use yii\base\DynamicModel;
+use yii\base\InvalidConfigException;
+use yii\db\ActiveRecord;
+use yii\db\Query;
+use yii\rest\ActiveController;
+
+/**
+ * Class TerminalController
+ * @package app\api\controllers
+ */
+class TerminalController extends ActiveController
+{
+    /**
+     * @var string
+     */
+    public $modelClass = Terminal::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function behaviors(): array
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => TerminalAuthentication::class,
+        ];
+        return $behaviors;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verbs()
+    {
+        return [
+            'in' => ['POST'],
+            'out' => ['POST'],
+            'working' => ['GET'],
+            'summary' => ['GET'],
+            'users' => ['GET'],
+            'update' => ['GET'],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function actions(): array
+    {
+        $actions = parent::actions();
+        unset($actions['index'], $actions['view'], $actions['create'], $actions['update'], $actions['delete']);
+        return $actions;
+    }
+
+    public function actionIn()
+    {
+        $params = (new DynamicModel(['user_id']))->addRule(['user_id'], 'required')
+            ->addRule(['user_id'], 'exist', ['targetClass' => User::class, 'targetAttribute' => 'id']);
+
+        $params->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if (!$params->validate()) {
+            return $params;
+        }
+
+        $clock = new Clock();
+        $now = Clock::roundToFullMinute((int)Yii::$app->formatter->asTimestamp('now'));
+
+        if (Clock::find()->where(['clock_out' => null, 'user_id' => $params['user_id']])->exists()) {
+            return 'session has already been started';
+        }
+
+        $clock->clock_in = $now;
+        $clock->clock_out = null;
+        $clock->user_id = $params['user_id'];
+
+        if (!$clock->validate()) {
+            return $clock->errors;
+        }
+
+        return $clock->save(false);
+    }
+
+    public function actionOut()
+    {
+        $params = (new DynamicModel(['user_id']))->addRule(['user_id'], 'required')
+            ->addRule(['user_id'], 'exist', ['targetClass' => User::class, 'targetAttribute' => 'id']);
+
+        $params->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if (!$params->validate()) {
+            return $params;
+        }
+
+        if (!Clock::find()->where(['clock_out' => null, 'user_id' => $params['user_id']])->exists()) {
+            return 'could not find session';
+        }
+
+        $clock = Clock::find()->where(['clock_out' => null, 'user_id' => $params['user_id']])->one();
+
+        $clock->clock_out = Clock::roundToFullMinute((int)Yii::$app->formatter->asTimestamp('now'));
+
+        if (!$clock->validate()) {
+            return $clock->errors;
+        }
+
+        if ($clock->isAnotherSessionSaved()) {
+            return 'can not end current session because it overlaps with another ended session';
+        }
+
+        return $clock->save(false);
+    }
+
+    /**
+     * Returns running sessions
+     * @return array
+     */
+    public function actionWorking()
+    {
+        return Clock::find()->where(['clock_out' => null])->orderBy(['user_id' => SORT_ASC])
+            ->select(['user_id', 'clock_in'])->all();
+    }
+
+    /**
+     * Returns work and vacation summary of given user
+     * user id, today's work, this week's work, last week's work, approved vacation
+     * @return array|DynamicModel
+     * @throws InvalidConfigException
+     */
+    public function actionSummary()
+    {
+        $params = (new DynamicModel(['user_id']))->addRule(['user_id'], 'required')
+            ->addRule(['user_id'], 'exist', ['targetClass' => User::class, 'targetAttribute' => 'id']);
+
+        $params->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if (!$params->validate()) {
+            return $params;
+        }
+
+        $vacationDays = 0;
+        $vacations = Off::find()
+            ->where(['and', ['user_id' => $params['user_id']], ['type' => Off::TYPE_VACATION], ['approved' => 1]])
+            ->all();
+        foreach ($vacations as $vacation) {
+            $vacationDays += $vacation->getWorkDaysOfOffPeriod();
+        }
+
+        $today = (new DateTime)->setTime(0, 0);
+        $tomorrow = (clone $today)->modify('+1 day');
+        $weekMon = (clone $today)->modify('this week');
+        $nextWeekMon = (clone $today)->modify('this week +7 days');
+        $lastWeekMon = (clone $today)->modify('last week');
+
+        $today = (new Query())->from(Clock::tableName())
+            ->select(['SUM(clock_out - clock_in) sum',])
+            ->where(
+                [
+                    'and',
+                    ['user_id' => $params['user_id']],
+                    ['is not', 'clock_out', null],
+                    ['>=', 'clock_in', $today->getTimestamp()],
+                    ['<', 'clock_out', $tomorrow->getTimestamp()],
+                ]
+            )->one();
+
+        $thisWeek = (new Query())->from(Clock::tableName())
+            ->select(['SUM(clock_out - clock_in) sum',])
+            ->where(
+                [
+                    'and',
+                    ['user_id' => $params['user_id']],
+                    ['is not', 'clock_out', null],
+                    ['>=', 'clock_in', $weekMon->getTimestamp()],
+                    ['<', 'clock_out', $nextWeekMon->getTimestamp()],
+                ]
+            )->one();
+
+        $lastWeek = (new Query())->from(Clock::tableName())
+            ->select(['SUM(clock_out - clock_in) sum',])
+            ->where(
+                [
+                    'and',
+                    ['user_id' => $params['user_id']],
+                    ['is not', 'clock_out', null],
+                    ['>=', 'clock_in', $lastWeekMon->getTimestamp()],
+                    ['<', 'clock_out', $weekMon->getTimestamp()],
+                ]
+            )->one();
+
+        return [
+            'today' => (int)$today['sum'] ?? 0,
+            'this_week' => (int)$thisWeek['sum'] ?? 0,
+            'last_week' => (int)$lastWeek['sum'] ?? 0,
+            'vacation' => $vacationDays ?? 0,
+        ];
+    }
+
+    /**
+     * Returns user data
+     * id, name, tag id, picture
+     * TODO: Add tag id and picture
+     * @return array|ActiveRecord[]
+     */
+    public function actionUsers()
+    {
+        return User::find()->where(['status' => User::STATUS_ACTIVE])->select(['id', 'name'])->all();
+    }
+
+    /**
+     * Returns timestamp of latest user update
+     * @return array|ActiveRecord|null
+     */
+    public function actionUpdate()
+    {
+        return User::find()->where(['status' => User::STATUS_ACTIVE])->orderBy(['updated_at' => SORT_DESC])
+            ->select(['updated_at'])->one();
+    }
+}

--- a/src/commands/TerminalController.php
+++ b/src/commands/TerminalController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\commands;
+
+use app\models\Terminal;
+use app\models\User;
+use Yii;
+use yii\base\Exception;
+use yii\console\Controller;
+use yii\console\ExitCode;
+
+/**
+ * Allows you to set any registered user as admin.
+ * Class AdminController
+ * @package app\commands
+ */
+class TerminalController extends Controller
+{
+    /**
+     * Add terminal account
+     * @return int
+     * @throws Exception
+     */
+    public function actionAdd(): int
+    {
+        do {
+            $apiKey = Yii::$app->security->generateRandomString(20);
+        } while (Terminal::find()->where(['api_key' => $apiKey])->exists() ||
+        User::find()->where(['api_key' => $apiKey])->exists());
+
+        $terminal = new Terminal();
+        $terminal->api_key = $apiKey;
+
+        if (!$terminal->save()) {
+            Yii::error($terminal->errors);
+            $this->stdout("Error while saving new terminal account.\n");
+            return ExitCode::SOFTWARE;
+        }
+
+        $this->stdout("A new terminal account was registered. Please note the API key: '{$terminal->api_key}'\n");
+        return ExitCode::OK;
+    }
+
+    /**
+     * Delete terminal account
+     * @param $id
+     * @return int
+     */
+    public function actionDelete($id): int
+    {
+        $account = Terminal::findOne(['id' => $id]);
+
+        if (empty($account)) {
+            $this->stdout("Can not find terminal account of given ID.\n");
+            return ExitCode::SOFTWARE;
+        } elseif ($account->delete() == false) {
+            Yii::error($account->errors);
+            $this->stdout("Error while deleting terminal account.\n");
+            return ExitCode::SOFTWARE;
+        }
+
+        $this->stdout("Deleted terminal account of given ID successfully.\n");
+        return ExitCode::OK;
+    }
+
+    /**
+     * List all terminal accounts
+     * @return int
+     */
+    public function actionList(): int
+    {
+        $accounts = Terminal::find()->orderBy(['id' => SORT_ASC])->all();
+
+        if (empty($accounts)) {
+            $this->stdout("No terminal accounts registered.\n");
+        } else {
+            $this->stdout("Following terminal accounts are currently registered:\n");
+        }
+
+        foreach ($accounts as $account) {
+            $this->stdout("ID: '{$account->id}' \t API key: '{$account->api_key}'\n");
+        }
+
+        return ExitCode::OK;
+    }
+}

--- a/src/config/rules.php
+++ b/src/config/rules.php
@@ -44,6 +44,12 @@ return [
             '' => 'options',
         ],
     ],
+    [
+        'class' => UrlRule::class,
+        'controller' => 'api/terminal',
+        'only' => ['working', 'summary', 'in', 'out', 'users', 'update'],
+        'pluralize' => false,
+    ],
     'site/new-password/<token:\w+>' => 'site/new-password',
     'clock/<action:[\w\-]+>/<day:\d+>/<month:\d+>/<year:\d+>' => 'clock/<action>',
     'clock/<action:[\w\-]+>/<month:\d+>/<year:\d+>' => 'clock/<action>',

--- a/src/config/rules.php
+++ b/src/config/rules.php
@@ -47,7 +47,7 @@ return [
     [
         'class' => UrlRule::class,
         'controller' => 'api/terminal',
-        'only' => ['working', 'summary', 'in', 'out', 'users', 'update'],
+        'only' => ['working', 'summary', 'in', 'out', 'users', 'update', 'image'],
         'pluralize' => false,
     ],
     'site/new-password/<token:\w+>' => 'site/new-password',

--- a/src/config/web.php
+++ b/src/config/web.php
@@ -86,6 +86,7 @@ $config = [
         'company' => 'Company Name',
         'email' => 'email@company.com',
         'allowedDomains' => ['@company.com'],
+        'uploadPath' => dirname(__DIR__) . '/../uploads/',
     ],
 ];
 

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -9,6 +9,7 @@ use app\models\Clock;
 use app\models\Holiday;
 use app\models\Off;
 use app\models\Project;
+use app\models\TerminalForm;
 use app\models\User;
 use Exception;
 use Throwable;
@@ -25,6 +26,7 @@ use yii\helpers\Url;
 use yii\web\BadRequestHttpException;
 use yii\web\RangeNotSatisfiableHttpException;
 use yii\web\Response;
+use yii\web\UploadedFile;
 
 use function array_merge;
 use function date;
@@ -90,6 +92,7 @@ class AdminController extends BaseController
                 'history',
                 'off',
                 'calendar',
+                'terminal-edit',
             ]
         );
     }
@@ -1159,5 +1162,34 @@ class AdminController extends BaseController
         }
 
         return $this->redirect(['index']);
+    }
+
+    /**
+     * @param $id
+     * @return string
+     */
+    public function actionTerminalEdit($id)
+    {
+        $user = User::findOne($id);
+        if ($user === null) {
+            Yii::$app->alert->danger(Yii::t('app', 'Can not find user of given ID.'));
+            return $this->goBack();
+        }
+
+        $model = new TerminalForm($user);
+
+        if ($model->load(Yii::$app->request->post())) {
+            if (!$model->delete) {
+                $model->imageFile = UploadedFile::getInstance($model, 'imageFile');
+            }
+            if ($model->save()) {
+                Yii::$app->alert->success(Yii::t('app', 'Terminal data has been saved.'));
+                return $this->goBack();
+            } else {
+                Yii::$app->alert->success(Yii::t('app', 'Error while saving terminal data.'));
+            }
+        }
+
+        return $this->render('terminal-edit', ['model' => $model]);
     }
 }

--- a/src/messages/de/app.php
+++ b/src/messages/de/app.php
@@ -347,4 +347,12 @@ return [
     '{n,plural,one{# day} other{# days}}' => '{n,plural,one{# Tag} other{# Tage}}',
     '{n,plural,one{# session} other{# sessions}}' => '{n,plural,one{# Sitzung} other{# Sitzungen}}',
     '{timestamp} is integer with number of seconds since the beginning of Unix Epoch on January 1st, 1970 at UTC. You must provide current timestamp like for example now - {now}. API will reject all requests older or younger by 1 minute from current time.' => 'Der {timestamp} ist eine Integerzahl mit der Anzahl der Sekunden seit Beginn der Unix Epoche am 01.01.1970 UTC. Beispiel: {now}. Die API lehnt alle Anfragen, die älter als eine Minute sind ab.',
+    'add to terminal' => 'Terminal',
+    'Terminal data has been saved.' => 'Daten wurden gespeichert.',
+    'Error while saving terminal data.' => 'Beim Speichern ist ein Fehler aufgetreten.',
+    'RFID Tag Identifier' => 'RFID Tag Identifikator',
+    'If you want to upload an image, select one:' => 'Wähle ein Bild aus, wenn du eines hochladen möchtest:',
+    'Do you want to delete the current picture?' => 'Möchtest du das aktuelle Bild löschen?',
+    'Adding Terminal Data' => 'Terminal Daten hinzufügen',
+    'Upload / Keep' => 'Hochladen / Behalten',
 ];

--- a/src/messages/pl/app.php
+++ b/src/messages/pl/app.php
@@ -347,4 +347,12 @@ return [
     '{n,plural,one{# day} other{# days}}' => '{n,plural,one{# dzień} other{# dni}}',
     '{n,plural,one{# session} other{# sessions}}' => '{n,plural,one{# sesja} few{# sesje} many{# sesji} other{# sesji}}',
     '{timestamp} is integer with number of seconds since the beginning of Unix Epoch on January 1st, 1970 at UTC. You must provide current timestamp like for example now - {now}. API will reject all requests older or younger by 1 minute from current time.' => '{timestamp} jest liczbą całkowitą oznaczającą sekundy, które upłynęły od początku Epoki Uniksa 1 stycznia 1970 czasu UTC. Musisz podać aktualny znacznik czasu jak dla przykłądu w tej chwili - {now}. API odrzuci każde zapytanie starsze lub młodsze o 1 minutę od aktualnego czasu serwera.',
+    'add to terminal' => 'add to terminal',
+    'Terminal data has been saved.' => 'Terminal data has been saved.',
+    'Error while saving terminal data.' => 'Error while saving terminal data.',
+    'RFID Tag Identifier' => 'RFID Tag Identifier',
+    'If you want to upload an image, select one:' => 'If you want to upload an image, select one:',
+    'Do you want to delete the current picture?' => 'Do you want to delete the current picture?',
+    'Adding Terminal Data' => 'Adding Terminal Data',
+    'Upload / Keep' => 'Upload / Keep',
 ];

--- a/src/migrations/m201023_204816_terminal.php
+++ b/src/migrations/m201023_204816_terminal.php
@@ -1,0 +1,27 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m201023_204816_terminal
+ */
+class m201023_204816_terminal extends Migration
+{
+    public function up()
+    {
+        $tableOptions = null;
+        if ($this->db->driverName === 'mysql') {
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
+        }
+
+        $this->createTable('{{%terminal}}', [
+            'id' => $this->primaryKey(),
+            'api_key' => $this->string(20)->unique(),
+        ], $tableOptions);
+    }
+
+    public function down()
+    {
+        $this->dropTable('{{%terminal}}');
+    }
+}

--- a/src/migrations/m201024_190235_user.php
+++ b/src/migrations/m201024_190235_user.php
@@ -1,0 +1,21 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m201024_190235_user
+ */
+class m201024_190235_user extends Migration
+{
+    public function up()
+    {
+        $this->addColumn('{{%user}}', 'tag', $this->string());
+        $this->addColumn('{{%user}}', 'image', $this->string());
+    }
+
+    public function down()
+    {
+        $this->dropColumn('{{%user}}', 'tag');
+        $this->dropColumn('{{%user}}', 'image');
+    }
+}

--- a/src/models/Terminal.php
+++ b/src/models/Terminal.php
@@ -47,6 +47,18 @@ class Terminal extends ActiveRecord
     }
 
     /**
+     * Check if at least one terminal account is registered
+     * @return bool
+     */
+    public static function isActive()
+    {
+        if (empty(static::find()->one())) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * @param mixed $token
      * @param null $type
      * @return self

--- a/src/models/Terminal.php
+++ b/src/models/Terminal.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use yii\db\ActiveRecord;
+use yii\web\ForbiddenHttpException;
+
+use function preg_match;
+use function sha1;
+use function time;
+
+/**
+ * Terminal model
+ *
+ * @property int $id
+ * @property string $api_key
+ */
+class Terminal extends ActiveRecord
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function tableName(): string
+    {
+        return '{{%terminal}}';
+    }
+
+    /**
+     * @param $id
+     * @return static|null
+     */
+    public static function findIdentity($id): ?self
+    {
+        return static::findOne(['id' => $id]);
+    }
+
+    /**
+     * @param string $stamp
+     * @param string $checksum
+     * @return bool
+     */
+    public function verifyChecksum(string $stamp, string $checksum): bool
+    {
+        return sha1($stamp . $this->api_key) === $checksum;
+    }
+
+    /**
+     * @param mixed $token
+     * @param null $type
+     * @return self
+     * @throws ForbiddenHttpException
+     */
+    public static function findIdentityByAccessToken($token): self
+    {
+        if (!preg_match('/^(\d+):(\d+):(.+)$/', $token, $matches)) {
+            throw new ForbiddenHttpException('Invalid token provided');
+        }
+
+        [, $id, $stamp, $checksum] = $matches;
+
+        $now = time();
+
+        if ($now > $stamp + 60 || $now < $stamp - 60) {
+            throw new ForbiddenHttpException('Invalid token provided');
+        }
+
+        $terminal = static::findIdentity($id);
+
+        if ($terminal === null || empty($terminal->api_key) || !$terminal->verifyChecksum($stamp, $checksum)) {
+            throw new ForbiddenHttpException('Invalid token provided');
+        }
+
+        return $terminal;
+    }
+
+}

--- a/src/models/TerminalForm.php
+++ b/src/models/TerminalForm.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use Exception;
+use Yii;
+use yii\base\Model;
+use yii\web\UploadedFile;
+
+/**
+ * Class ClockForm
+ * @package app\models
+ */
+class TerminalForm extends Model
+{
+    /**
+     * @var string
+     */
+    public $tag;
+
+    /**
+     * @var string
+     */
+    public $image;
+
+    /**
+     * @var UploadedFile
+     */
+    public $imageFile;
+
+    /**
+     * @var boolean
+     */
+    public $delete;
+
+    /**
+     * @var User
+     */
+    private $_user;
+
+    /**
+     * TerminalForm constructor.
+     * @param User $session
+     * @param array $config
+     */
+    public function __construct(User $session, array $config = [])
+    {
+        $this->_user = $session;
+        $this->tag = !empty($session->tag) ? $session->tag : null;
+        $this->image = !empty($session->image) ? $session->image : null;
+        parent::__construct($config);
+    }
+
+    /**
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            [['tag'], 'required'],
+            [['tag'], 'string'],
+            [['imageFile'], 'file', 'extensions' => 'png, jpg'],
+            [['delete'], 'required'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function attributeLabels(): array
+    {
+        return [
+            'tag' => Yii::t('app', 'RFID Tag Identifier'),
+            'imageFile' => Yii::t('app', 'If you want to upload an image, select one:'),
+            'delete' => Yii::t('app', 'Do you want to delete the current picture?'),
+        ];
+    }
+
+    /**
+     * @return bool
+     * @throws Exception
+     */
+    public function save(): bool
+    {
+        if (!$this->validate()) {
+            return false;
+        }
+
+        if ($this->imageFile) {
+            $this->imageFile->saveAs(Yii::$app->params['uploadPath'] . $this->imageFile->name);
+        }
+
+        if ($this->delete && !empty($this->_user->image)) {
+            unlink(Yii::$app->params['uploadPath'] . $this->image);
+            $this->_user->image = null;
+        } elseif (!$this->delete && $this->imageFile) {
+            $this->_user->image = $this->imageFile->name;
+        }
+
+        $this->_user->tag = !empty($this->tag) ? $this->tag : null;
+
+        return $this->_user->save();
+    }
+}

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -42,6 +42,8 @@ use function time;
  * @property int $created_at
  * @property int $updated_at
  * @property string $password write-only password
+ * @property string $tag
+ * @property string $image
  *
  * @property string $initials
  * @property array $assignedProjects

--- a/src/views/admin/index.php
+++ b/src/views/admin/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use app\models\Terminal;
 use app\models\User;
 use app\widgets\confirm\Confirm;
 use app\widgets\fontawesome\FA;
@@ -83,6 +84,11 @@ $this->title = Yii::t('app', 'Employees');
                         <?php endif; ?>
                     </td>
                     <td class="text-right text-nowrap">
+                        <?php if (Terminal::isActive()): ?>
+                            <a href="<?= Url::to(['admin/terminal-edit', 'id' => $user->id]) ?>" class="btn btn-success btn-sm">
+                                <?= FA::icon('desktop') ?> <span class="d-none d-lg-inline"><?= Yii::t('app', 'add to terminal') ?></span>
+                            </a>
+                        <?php endif; ?>
                         <?php if ($user->status !== User::STATUS_DELETED): ?>
                         <a href="<?= Url::to(['admin/reset', 'id' => $user->id]) ?>"
                            class="btn btn-warning btn-sm"

--- a/src/views/admin/terminal-edit.php
+++ b/src/views/admin/terminal-edit.php
@@ -1,0 +1,65 @@
+<?php
+
+use app\models\TerminalForm;
+use app\widgets\fontawesome\FA;
+use yii\bootstrap4\ActiveForm;
+use yii\bootstrap4\Html;
+use yii\helpers\Url;
+
+/**
+ * @var $this yii\web\View
+ * @var $model TerminalForm
+ */
+
+$this->title = Yii::t('app', 'Adding Terminal Data');
+
+$this->registerJs(<<<JS
+    $(document).ready(function() { 
+        document.getElementById('terminalform-delete').onclick = function() {
+                var box = document.querySelector('input[name="TerminalForm[delete]"]:checked');
+                if (box) {
+                    if (box.value === '1') {
+                        document.getElementsByClassName('field-terminalform-imagefile')[0].style.display = 'none';
+                    } else {
+                        document.getElementsByClassName('field-terminalform-imagefile')[0].style.display = 'block';
+                    }
+                }
+        }
+    });
+JS
+);
+?>
+
+<div class="form-group">
+    <h1><?= Yii::t('app', 'Adding Terminal Data') ?></h1>
+</div>
+
+<div class="row">
+    <div class="col-lg-2">
+        <div class="form-group">
+            <a href="<?= Url::previous() ?>" class="btn btn-outline-primary btn-block">
+                <?= FA::icon('backward') ?>
+                <?= Yii::t('app', 'Go Back') ?>
+            </a>
+        </div>
+    </div>
+    <div class="col-lg-8">
+        <?php $form = ActiveForm::begin(); ?>
+            <?= $form->field($model, 'tag')->textInput() ?>
+            <?= $form->field($model, 'delete')->radioList([
+                    true => Yii::t('app', 'Delete'),
+                    false => Yii::t('app', 'Upload / Keep')])
+            ?>
+            <?= $form->field($model, 'imageFile')->fileInput() ?>
+            <div class="form-group text-right">
+                <?= Html::submitButton(
+                    FA::icon('check-circle') . ' ' . Yii::t('app', 'Save'),
+                    [
+                        'class' => 'btn btn-primary',
+                        'name' => 'save-button',
+                    ]
+                ) ?>
+            </div>
+        <?php ActiveForm::end(); ?>
+    </div>
+</div>


### PR DESCRIPTION
As explained in #17 I implemented an API endpoint and custom authentication for a clock in/out terminal like this one [rpi-timeclock-terminal](https://github.com/niclasku/rpi-timeclock-terminal). I was not sure about the error handling in api/controllers/TerminalController. It works for me but it might be more elegant to not only return error strings.

I have done the following:
- Add terminal model for identification and authentication of terminals
- Add console controller to add/delete/list registered terminals
- Add authentication based on terminal model for API endpoints 
- Add restricted terminal API endpoint
- Add tag id and profile picture path to user model
- Add form to edit tag id and profile picture for admins
- Extend bootstrap container width for wide screens

Missing:
- Polish translation (strings already added to messages/pl/app.php)

Feedback and suggestions are very welcome!